### PR TITLE
Fix a bug

### DIFF
--- a/src/file.reading.cc
+++ b/src/file.reading.cc
@@ -343,11 +343,13 @@ struct SimpleGwasFile : public file_reading:: Effects_I
             );
     }
     virtual void        delete_snps_with_no_position() {
-        for(int i=0; i<utils::ssize(m_each_SNP_and_its_z); ++i) {
+        for(int i=0; i<utils::ssize(m_each_SNP_and_its_z);) {
             if(this->get_chrpos(i) == chrpos{-1,-1}) {
                 assert( (m_each_SNP_and_its_z.begin()+i)->m_chrpos == chrpos({-1,-1}) );
                 m_each_SNP_and_its_z.erase(m_each_SNP_and_its_z.begin() + i);
             }
+            else
+                ++i;
         }
     }
 

--- a/src/ssimp.cc
+++ b/src/ssimp.cc
@@ -114,6 +114,13 @@ ostream & operator<<(ostream & o, which_build_t w) {
     }
     return o;
 }
+static
+int add_one_if_not_negative(int x) {
+    if(x==-1)
+        return -1;
+    else
+        return x+1;
+}
 chrpos get_one_build(IDchrmThreePos const & db_entry, which_build_t which_build) {
     int chrm = db_entry.chrom;
     switch(which_build) {
@@ -121,9 +128,12 @@ chrpos get_one_build(IDchrmThreePos const & db_entry, which_build_t which_build)
         break; case which_build_t:: hg19_0: return { chrm, db_entry.hg19 };
         break; case which_build_t:: hg20_0: return { chrm, db_entry.hg20 };
 
-        break; case which_build_t:: hg18_1: return { chrm, db_entry.hg18+1 };
-        break; case which_build_t:: hg19_1: return { chrm, db_entry.hg19+1 };
-        break; case which_build_t:: hg20_1: return { chrm, db_entry.hg20+1 };
+        // otherwise, we want to add one to the position, but only if the
+        // position is not -1. i.e. not unknown.
+        // We want to keep '-1' to mean "unknown position"
+        break; case which_build_t:: hg18_1: return { chrm, add_one_if_not_negative(db_entry.hg18) };
+        break; case which_build_t:: hg19_1: return { chrm, add_one_if_not_negative(db_entry.hg19) };
+        break; case which_build_t:: hg20_1: return { chrm, add_one_if_not_negative(db_entry.hg20) };
 
         break; default: ;
     }

--- a/src/ssimp.cc
+++ b/src/ssimp.cc
@@ -735,9 +735,15 @@ int main(int argc, char **argv) {
                         auto offset_into_big_db = database_of_builds_rs_to_offset[gwas_rs_int];
                         assert(database_of_builds.at(offset_into_big_db).rs == gwas_rs_int);
                         chrpos new_chrpos = get_one_build(database_of_builds.at(offset_into_big_db), which_build_ref);
-                        //PP(gwas_rs_int, new_chrpos);
-                        assert(new_chrpos != (chrpos{-1,0}));
-                        gwas->set_chrpos(i, new_chrpos);
+                        if (new_chrpos.pos == -1) {
+                            // we can't do anything here, as we don't know its position.
+                            // This is a SNP which is known in at least one build (hence
+                            // it's in the database), but it's not known in the desired
+                            // build
+                        } else {
+                            assert(new_chrpos != (chrpos{-1,0}));
+                            gwas->set_chrpos(i, new_chrpos);
+                        }
                     } else {
                         // not in the database - should we delete it?
                         // TODO: decide whether to delete or now

--- a/src/ssimp.cc
+++ b/src/ssimp.cc
@@ -725,7 +725,11 @@ int main(int argc, char **argv) {
         if(which_build_gwas == ssimp:: which_build_t:: unknown) {
             // let's copy in as much as we can from the database into the gwas.
             // We only have the rs-number to go on though.
-            for(int i = 0; i<gwas->number_of_snps(); ++i ) { assert(gwas->get_chrpos(i) != (chrpos{-1,0}) ); }
+            for(int i = 0; i<gwas->number_of_snps(); ++i ) {
+                // first, clear out any position already assigned. We
+                // don't know the build, so we can't really trust them.
+                gwas->set_chrpos(i, chrpos{-1,-1});
+            }
             for(int i = 0; i<gwas->number_of_snps(); ++i ) {
                 auto   gwas_rs      =   gwas->get_SNPname(i);
                 if(gwas_rs.substr(0,2) == "rs") {


### PR DESCRIPTION
There are multiple parts to the bug:

1 - If a gwas SNP has unknown position, its chromosome and position are recorded as {-1,-1}. If we can't fill in the position from the rs number, via the build, then the GWAS SNP will be deleted. This is part of the original design

2 - If a SNP is known in one build, but not another, then it's position is recorded is recorded for all builds, but is recorded as {-1, -1} in the builds where the rs-number isn't known.

3 - When copying SNPs from the build database into the GWAS , we often have to add one to the position. The system for detecting the build number doesn't only decide among three builds, it also estimates whether we need to add one to the position. This gives six different possibilities

The problem occurs where all three of these come together, Instead of copying {-1,-1} from the build database into the GWAS, it copies {-1,0} (because one has been added). Then we have a GWAS SNP with an invalid position, but it's not removed.

The easiest way to understand this fix, and the bug that it resolves, is to look at the function `add_one_if_not_negative` that is added here. When adding one to the position, it leaves -1 unchanged